### PR TITLE
Dodanie autoryzacji w oparciu o tokeny

### DIFF
--- a/backend/backend/app.py
+++ b/backend/backend/app.py
@@ -2,14 +2,14 @@ from fastapi import FastAPI
 from fastapi_users import FastAPIUsers
 from .user_manager import get_user_manager
 from .models import User, UserCreate, UserDB, UserUpdate
-from .auth import auth_backend
+from .auth import cookie_backend, token_backend
 from .measurements import MeasurementRouter
 from .files import FileRouter
 from .tea import router as tea
 
 fastapi_users = FastAPIUsers(
     get_user_manager,
-    [auth_backend],
+    [cookie_backend, token_backend],
     User,
     UserCreate,
     UserUpdate,
@@ -41,8 +41,14 @@ async def startup_event():
 
 
 app.include_router(
-    fastapi_users.get_auth_router(auth_backend),
-    prefix="/api/auth",
+    fastapi_users.get_auth_router(cookie_backend),
+    prefix="/api/cookie",
+    tags=["auth"],
+)
+
+app.include_router(
+    fastapi_users.get_auth_router(token_backend),
+    prefix="/api/jwt",
     tags=["auth"],
 )
 

--- a/backend/backend/auth.py
+++ b/backend/backend/auth.py
@@ -15,7 +15,7 @@ def get_database_strategy(
     return DatabaseStrategy(access_token_db, lifetime_seconds=3600)
 
 
-from fastapi_users.authentication import CookieTransport
+from fastapi_users.authentication import CookieTransport, BearerTransport
 
 cookie_transport = CookieTransport(
     cookie_max_age=36000,
@@ -24,6 +24,14 @@ cookie_transport = CookieTransport(
     cookie_samesite="strict",
 )
 
-auth_backend = AuthenticationBackend(
+cookie_backend = AuthenticationBackend(
     name="cookie", transport=cookie_transport, get_strategy=get_database_strategy
+)
+
+token_transport = BearerTransport(
+    tokenUrl="/api/jwt/login"
+)
+
+token_backend = AuthenticationBackend(
+    name="jwt", transport=token_transport, get_strategy=get_database_strategy
 )


### PR DESCRIPTION
Dodano autoryzację w oparciu o tokeny JWT-podobne.

W zasadzie jest to ciastko transportowane jako token, ale działa więc nie narzekamy.